### PR TITLE
Implementation of Davenport projections

### DIFF
--- a/domain/domain.py
+++ b/domain/domain.py
@@ -352,11 +352,18 @@ class PlayerProjection(Base):
     pitcher = Column(Boolean)
     two_way = Column(Boolean)
 
-    def get_stat(self, stat_type:StatType) -> ProjectionData:
-        '''Gets the ProejctionData associated with the input StatType'''
+    def get_stat(self, stat_type:StatType) -> float:
+        '''Gets the stat value associated with the input StatType'''
+        pd = self.get_projection_data(stat_type)
+        if pd is None:
+            return None
+        return pd.stat_value
+
+    def get_projection_data(self, stat_type:StatType) -> ProjectionData:
+        '''Gets the ProjectionData object associated with the input StatType'''
         for pd in self.projection_data:
             if pd.stat_type == stat_type:
-                return pd.stat_value
+                return pd
         return None
 
 class ProjectionData(Base):

--- a/domain/enum.py
+++ b/domain/enum.py
@@ -269,6 +269,7 @@ class StatType(Enum):
     PPG = 44
     PIP = 45
 
+
     @classmethod
     def hit_to_enum_dict(self):
         return {
@@ -294,7 +295,16 @@ class StatType(Enum):
         'OPS' : self.OPS,
         'wOBA' : self.WOBA,
         'wRC+' : self.WRC_PLUS,
-        'BABIP' : self.BABIP_H
+        'BABIP' : self.BABIP_H,
+        'G_C' : self.G_HIT,
+        'G_FB' : self.G_HIT,
+        'G_SB' : self.G_HIT,
+        'G_3B' : self.G_HIT,
+        'G_SS' : self.G_HIT,
+        'G_LF' : self.G_HIT,
+        'G_CF' : self.G_HIT,
+        'G_RF' : self.G_HIT,
+        'G_DH' : self.G_HIT
     }
 
     @classmethod
@@ -308,6 +318,7 @@ class StatType(Enum):
         'QS' : self.QS,
         'SV' : self.SV,
         'HLD' : self.HLD,
+        'Holds' : self.HLD,
         'H' : self.H_ALLOWED,
         'ER' : self.ER,
         'HR' : self.HR_ALLOWED,

--- a/domain/enum.py
+++ b/domain/enum.py
@@ -11,8 +11,15 @@ class ProjectionType(Enum):
     THE_BATX = 5
     CUSTOM = 6
     VALUE_DERIVED = 7
+    DAVENPORT = 8
 
-    fg_downloadable = [STEAMER, ZIPS, DEPTH_CHARTS, ATC, THE_BAT, THE_BATX]
+    @classmethod
+    def get_fg_downloadable(self):
+        return [self.STEAMER, self.ZIPS, self.DEPTH_CHARTS, self.ATC, self.THE_BAT, self.THE_BATX]
+    
+    @classmethod
+    def get_downloadable(self):
+        return [self.DAVENPORT, self.STEAMER, self.ZIPS, self.DEPTH_CHARTS, self.ATC, self.THE_BAT, self.THE_BATX]
 
     @classmethod
     def enum_to_name_dict(self):
@@ -24,7 +31,8 @@ class ProjectionType(Enum):
         self.THE_BAT : "THE BAT",
         self.THE_BATX : "THE BATX",
         self.CUSTOM : "Custom",
-        self.VALUE_DERIVED: "Derived"
+        self.VALUE_DERIVED: "Derived",
+        self.DAVENPORT: "Davenport"
     }
 
     @classmethod
@@ -37,7 +45,8 @@ class ProjectionType(Enum):
         "THE BAT" : self.THE_BAT,
         "THE BATX" : self.THE_BATX,
         "Custom" : self.CUSTOM,
-        "Derived" : self.VALUE_DERIVED
+        "Derived" : self.VALUE_DERIVED,
+        "Davenport" : self.DAVENPORT
     }
 
     @classmethod
@@ -279,6 +288,7 @@ class StatType(Enum):
         'SB' : self.SB,
         'CS' : self.CS,
         'AVG' : self.AVG,
+        'BA'  : self.AVG,
         'OBP' : self.OBP,
         'SLG' : self.SLG,
         'OPS' : self.OPS,
@@ -545,6 +555,7 @@ class Position(Enum):
 class IdType(Enum):
     OTTONEU = 'Ottoneu'
     FANGRAPHS = 'FanGraphs'
+    MLB = 'MLBID'
 
 class PropertyType(Enum):
     DB_VERSION = 'db.version'

--- a/resources/THIRDPARTYLICENSE
+++ b/resources/THIRDPARTYLICENSE
@@ -1,7 +1,15 @@
+PROJECTION SOURCE ACKNOWLEDEMENTS
+
+Davenport projections are provided by Clay Davenport at https://claydavenport.com/projections/PROJHOME.shtml. Projections are provided free of charge, but donations are
+appreciated and can be made through his page.
+
+Steamer, ZiPs, ATC, THE BAT, and THE BATX projections are hosted by FanGraphs on https://www.fangraphs.com/. A paid FanGraphs account is required for access to these
+projections.
+
 THIRD-PARTY SOFTWARE LICENSE ACKNOWLEDGEMENTS
 
 -- MIT License --
-Used by: BeautifulSoup4, SQLAlchemy
+Used by: BeautifulSoup4, SQLAlchemy, pybaseball
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/scrape/exceptions.py
+++ b/scrape/exceptions.py
@@ -23,3 +23,8 @@ class CouchManagersException(Exception):
     def __init__(self, validation_msgs, *args: object) -> None:
         super().__init__(*args)
         self.validation_msgs = validation_msgs
+class DavenportException(Exception):
+    '''Exceptions related to scraping Davenport data.'''
+    def __init__(self, validation_msgs, *args: object) -> None:
+        super().__init__(*args)
+        self.validation_msgs = validation_msgs

--- a/scrape/scrape_base.py
+++ b/scrape/scrape_base.py
@@ -25,7 +25,7 @@ from scrape.exceptions import BrowserTypeException, DownloadException
 
 class Scrape_Base(object):
     '''Abstract scraper class'''
-    def __init__(self, browser):
+    def __init__(self, browser=None):
         self.driver = None
         self.browser = browser
         dirname = os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..'))
@@ -133,7 +133,7 @@ class Scrape_Base(object):
             service = EdgeService(EdgeChromiumDriverManager().install())
             service.creationflags = CREATE_NO_WINDOW
             self.driver = webdriver.Edge(service=service, options=options)
-        elif 'FirefoxURL' in self.browser:
+        elif self.browser is not None and 'FirefoxURL' in self.browser:
             options = webdriver.FirefoxOptions()
             options.add_argument('--headless')
             options.set_preference("browser.download.folderList", 2)

--- a/scrape/scrape_davenport.py
+++ b/scrape/scrape_davenport.py
@@ -1,0 +1,62 @@
+import pandas as pd
+from pandas import DataFrame
+import requests
+from io import StringIO
+from typing import Tuple, List
+import os
+
+from scrape import scrape_base
+from scrape.exceptions import DavenportException
+
+class Scrape_Davenport(scrape_base.Scrape_Base):
+
+    '''Implementation of Scrape_Base class for scraping information from Ottoneu website.'''
+    def __init__(self, browser:str=None):
+        super().__init__(browser)
+    
+    def get_projections(self) -> Tuple[DataFrame,DataFrame]:
+        '''Retrieves the Davenport projections as a tuple of DataFrames [position, pitcher] with an index of MLB Id'''
+        pos_df = self.__get_dataset(lookup_url='https://claydavenport.com/projections/hitter_projections.txt', csv_url='https://claydavenport.com/projections/clayhitters.csv', lookup_col=['IDNO','MLBID'])
+        pitch_df = self.__get_dataset(lookup_url='https://claydavenport.com/projections/pitcher_projections.txt', csv_url='https://claydavenport.com/projections/claypitchers.csv', lookup_col=['HOWEID','BPID'])
+        return (pos_df, pitch_df)
+
+    def __get_dataset(self, lookup_url:str, csv_url:str, lookup_col:List[str]) -> DataFrame:
+        response = requests.get(lookup_url)
+        pos_lookup = pd.read_csv(StringIO(response.text), delim_whitespace=True)[lookup_col]
+        pos_lookup.set_index(lookup_col[0], inplace=True)
+
+        s = requests.Session()
+        try:
+            response = s.get(csv_url)
+            if response.content is None or len(response.content) == 0:
+                raise DavenportException("Projections do not exist")
+            tmp_filepath = 'tmp/davenport.csv'
+            with open(tmp_filepath, 'wb') as f:
+                f.write(response.content)
+                f.close()
+            df = pd.read_csv(tmp_filepath)
+            df = df.loc[df['HOWEID'] != '0'] #Remove team rows
+            df['MLBID'] = df.apply(self.__get_mlbid, args=(pos_lookup,lookup_col), axis=1)
+            df = df.loc[df['MLBID'] != 0] #Remove blank rows
+            df.set_index('MLBID', inplace=True)
+            os.remove(tmp_filepath)
+        except Exception:
+            raise DavenportException('Error retrieving player projections.')
+        return df
+    
+    def __get_mlbid(self, row, lookup, col):
+        howeid = row['HOWEID']
+        if pd.isna(howeid):
+            return 0
+        #print(howeid)
+        return lookup.loc[howeid, col[1]]
+
+
+def main():
+    scraper = Scrape_Davenport()
+    dfs = scraper.get_projections()
+    print(dfs[0].head())
+    print(dfs[1].head())
+
+if __name__ == '__main__':
+    main()

--- a/services/draft_services.py
+++ b/services/draft_services.py
@@ -67,7 +67,8 @@ def get_couchmanagers_draft_dataframe(cm_draft_id:int) -> DataFrame:
     for idx, row in df.iterrows():
         if row['ottid'] == 0:
             name = f"{row['First Name']} {row['Last Name']}".upper()
-            players = player_services.search_by_name(name).sort(reverse=True, key=lambda p: p.get_salary_info_for_format().roster_percentage)
+            players = player_services.search_by_name(name)
+            players.sort(reverse=True, key=lambda p: p.get_salary_info_for_format().roster_percentage)
             if players is not None and len(players) > 0:
                 row['ottid'] = players[0].ottoneu_id
     return df

--- a/services/player_services.py
+++ b/services/player_services.py
@@ -52,10 +52,12 @@ def create_player(player_row:list, ottoneu_id:int=None, fg_id=None) -> Player:
     player.salary_info = []
     return player
 
-def get_player_by_fg_id(player_id) -> Player:
-    '''Returns player from database based on input FanGraphs player id. Will resolve either major or minor league id.'''
+def get_player_by_fg_id(player_id, force_major:bool=False) -> Player:
+    '''Returns player from database based on input FanGraphs player id. Will resolve either major or minor league id by default. If force_major is true, will only look for major league id'''
     with Session() as session:
-        if isinstance(player_id, int) or player_id.isdigit():
+        if force_major:
+            player = session.query(Player).filter(Player.fg_major_id == player_id).first()
+        elif isinstance(player_id, int) or player_id.isdigit():
             player = session.query(Player).filter(Player.fg_major_id == player_id).first()
         else:
             player = session.query(Player).filter(Player.fg_minor_id == player_id).first()

--- a/services/player_services.py
+++ b/services/player_services.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from sqlalchemy.orm import joinedload
+from pybaseball import playerid_reverse_lookup
 
 from domain.domain import Player, Salary_Refresh, Salary_Info
 from domain.enum import ScoringFormat, Position
@@ -147,3 +148,13 @@ def get_player_from_ottoneu_player_page(player_id: int, league_id: int) -> Playe
         player.salary_info.append(sal_info)
         session.add(sal_info)
     return player
+
+def get_player_by_mlb_id(player_id:int) -> Player:
+    '''Retrieves a player by MLB Id using the pybaseball playerid_reverse_lookup function to find FanGraphs id'''
+    fg_id = get_fg_id_by_mlb_id(player_id)
+    return get_player_by_fg_id(fg_id)
+
+def get_fg_id_by_mlb_id(player_id:int) -> str:
+    '''Retrieves a player's FanGraphs Id by MLB Id using the pybaseball playerid_reverse_lookup function'''
+    p_df = playerid_reverse_lookup([player_id])
+    return p_df.loc[0,'key_fangraphs']

--- a/services/player_services.py
+++ b/services/player_services.py
@@ -157,4 +157,7 @@ def get_player_by_mlb_id(player_id:int) -> Player:
 def get_fg_id_by_mlb_id(player_id:int) -> str:
     '''Retrieves a player's FanGraphs Id by MLB Id using the pybaseball playerid_reverse_lookup function'''
     p_df = playerid_reverse_lookup([player_id])
-    return p_df.loc[0,'key_fangraphs']
+    if len(p_df) > 0:
+        return p_df.loc[0,'key_fangraphs']
+    else:
+        return -1

--- a/services/projection_services.py
+++ b/services/projection_services.py
@@ -499,9 +499,24 @@ def projection_check(projs) -> None:
     '''Performs checks for uploaded projections'''
     # Perform checks here, update data as needed
     pitch_proj = projs[1]
-    if StatType.enum_to_display_dict()[StatType.HBP_ALLOWED] not in pitch_proj.columns:
+    if 'FIP' not in pitch_proj.columns and set(['IP', 'SO', 'BB', 'HBP', 'HR']).issubset(pitch_proj.columns):
+        pitch_proj['FIP'] = pitch_proj.apply(calc_fip, axis=1)
+    if 'HBP' not in pitch_proj.columns and 'BB' in pitch_proj.columns:
         # If HBP allowed is blank, fill with pre-calculated regression vs BB
         pitch_proj[StatType.enum_to_display_dict()[StatType.HBP_ALLOWED]] = pitch_proj[StatType.enum_to_display_dict()[StatType.BB_ALLOWED]].apply(lambda bb: 0.0951*bb+0.4181)
+    if 'FIP' not in pitch_proj.columns and set(['IP', 'SO', 'BB', 'HBP', 'HR']).issubset(pitch_proj.columns):
+        pitch_proj['FIP'] = pitch_proj.apply(calc_fip, axis=1)
+    if 'ERA' not in pitch_proj.columns and set(['IP', 'ER']).issubset(pitch_proj.columns):
+        pitch_proj['ERA'] = pitch_proj.apply(calc_era, axis=1)
+    if 'WHIP' not in pitch_proj.columns and set(['IP', 'H', 'BB']).issubset(pitch_proj.columns):
+        pitch_proj['WHIP'] = pitch_proj.apply(calc_whip, axis=1)
+    if 'HR/9' not in pitch_proj.columns and set(['IP', 'HR']).issubset(pitch_proj.columns):
+        pitch_proj['HR/9'] = pitch_proj.apply(calc_hr_per_9, axis=1)
+    if 'BB/9' not in pitch_proj.columns and set(['IP', 'BB']).issubset(pitch_proj.columns):
+        pitch_proj['BB/9'] = pitch_proj.apply(calc_bb_per_9, axis=1)
+    if 'K/9' not in pitch_proj.columns and set(['IP', 'SO']).issubset(pitch_proj.columns):
+        pitch_proj['K/9'] = pitch_proj.apply(calc_k_per_9, axis=1)
+    
 
 def get_projection_count() -> int:
     '''Returns number of Projections in database.'''

--- a/services/projection_services.py
+++ b/services/projection_services.py
@@ -1,5 +1,5 @@
 from pandas import DataFrame
-from domain.domain import PlayerProjection, Projection, ProjectionData
+from domain.domain import PlayerProjection, Projection, ProjectionData, Player
 from scrape import scrape_fg, scrape_davenport
 from domain.enum import ProjectionType, StatType, IdType
 from domain.exception import InputException
@@ -110,6 +110,7 @@ def save_projection(projection:Projection, projs:List[DataFrame], id_type:IdType
             inc_div = math.ceil(len(proj)/25)
             inc_count=0
             for idx, row in proj.iterrows():
+                player = None
                 if idx in seen_players:
                     player = seen_players[idx]
                     player_proj = projection.get_player_projection(player.index)
@@ -130,13 +131,14 @@ def save_projection(projection:Projection, projs:List[DataFrame], id_type:IdType
                             players.sort(reverse=True, key=lambda p: p.get_salary_info_for_format().roster_percentage)
                             if players is not None and len(players) > 0:
                                 for possible_player in players:
-                                    if possible_player.team is not None and possible_player.team.split(" ")[0] == row['Team']:
+                                    if match_team(possible_player, row['Team']):
                                         player = possible_player
                                         break
                                 if player is None:
                                     player = players[0]
                             else:
                                 player = None
+                            
                         else:
                             player = player_services.get_player_by_fg_id(str(id), force_major=True)
 
@@ -165,12 +167,16 @@ def save_projection(projection:Projection, projs:List[DataFrame], id_type:IdType
                         else:
                             stat_type = StatType.hit_to_enum_dict().get(col)                            
                         if stat_type != None:
-                            data = ProjectionData()
-                            data.stat_type = stat_type
-                            data.stat_value = row[col]
-                            if data.stat_value is None or math.isnan(data.stat_value):
-                                data.stat_value = 0
-                            player_proj.projection_data.append(data)
+                            if player_proj.get_projection_data(stat_type) is None:
+                                data = ProjectionData()
+                                data.stat_type = stat_type
+                                data.stat_value = row[col]
+                                if data.stat_value is None or math.isnan(data.stat_value):
+                                    data.stat_value = 0
+                                player_proj.projection_data.append(data)
+                            else:
+                                data = player_proj.get_projection_data(stat_type)
+                                data.stat_value = data.stat_value + row[col]
                 
                 inc_count += 1
                 if inc_count == inc_div and progress is not None:
@@ -182,6 +188,19 @@ def save_projection(projection:Projection, projs:List[DataFrame], id_type:IdType
 
         new_proj = get_projection(projection.index, player_data=False) 
     return new_proj
+
+def match_team(player:Player, team_name:str) -> bool:
+    if player.team is None:
+        return False
+    db_team = player.team.split(" ")[0]
+    if db_team == team_name:
+        return True
+    map = {'TBY': 'TBR',
+           'CWS': 'CHW',
+           'WAS': 'WSN'}
+    if team_name in map:
+        return db_team == map.get(team_name)
+    return False
 
 def create_projection_from_upload(projection: Projection, pos_file:str, pitch_file:str, name:str, desc:str='', ros:bool=False, year:int=None, progress=None):
     '''Creates a new projection from user inputs, saves it to the database, and returns the populated projection.'''

--- a/ui/dialog/help.py
+++ b/ui/dialog/help.py
@@ -9,7 +9,7 @@ class Dialog(tk.Toplevel):
         license_path = parent.get_resource_path(file)
         with open(license_path, 'r') as lic_fil:
             long_text = lic_fil.read()
-        text_widget = scrolledtext.ScrolledText(self, width=100, height=20,
+        text_widget = scrolledtext.ScrolledText(self, width=100, height=20, wrap=tk.WORD,
             font = font.nametofont("TkDefaultFont"))
 
         text_widget.insert(tk.INSERT, long_text)

--- a/ui/dialog/wizard/projection_import.py
+++ b/ui/dialog/wizard/projection_import.py
@@ -105,12 +105,14 @@ class Step1(tk.Frame):
         self.dc_btn = btn = ttk.Checkbutton(self.fg_self, text="DC Playing Time?", variable=self.dc_var)
         btn.grid(column=1,row=1)
         CreateToolTip(btn, 'Re-scale stats to FanGraphs Depth Charts playing time?')
+        btn.configure(state='disable')
 
         self.ros_var = tk.BooleanVar()
         self.ros_var.set(False)
         self.ros_btn = btn = ttk.Checkbutton(self.fg_self, text="RoS Projection?", variable=self.ros_var)
         btn.grid(column=1,row=2)
         CreateToolTip(btn, 'Use a Rest-of-Season projection?')
+        btn.configure(state='disable')
 
         self.custom_self = tk.Frame(self, borderwidth=4)
         self.custom_self.grid(row=3,column=0,columnspan=3)
@@ -160,6 +162,9 @@ class Step1(tk.Frame):
     def toggle_downloadable_proj(self):
         for child in self.fg_self.winfo_children():
             child.configure(state='active')
+        if self.proj_type.get() == ProjectionType.enum_to_name_dict().get(ProjectionType.DAVENPORT):
+            self.dc_btn.configure(state='disable')
+            self.ros_btn.configure(state='disable')
         for child in self.custom_self.winfo_children():
             child.configure(state='disable')
     

--- a/ui/dialog/wizard/projection_import.py
+++ b/ui/dialog/wizard/projection_import.py
@@ -117,7 +117,7 @@ class Step1(tk.Frame):
         self.custom_self = tk.Frame(self, borderwidth=4)
         self.custom_self.grid(row=3,column=0,columnspan=3)
 
-        id_map = [IdType.OTTONEU.value, IdType.FANGRAPHS.value]
+        id_map = [IdType.OTTONEU.value, IdType.FANGRAPHS.value, IdType.MLB.value]
         id_label = ttk.Label(self.custom_self, text="Player Id Type:")
         id_label.grid(column=0,row=0,pady=5, stick=W)
         id_label.configure(state='disabled')
@@ -242,6 +242,8 @@ class Step1(tk.Frame):
                             player = player_services.get_player_by_fg_id(id)
                         elif self.id_type.get() == IdType.OTTONEU.value:
                             player = player_services.get_player_by_ottoneu_id(id)
+                        elif self.id_type.get() == IdType.MLB.value:
+                            player = player_services.get_player_by_mlb_id(id)
                         found_player = player is not None
                         idx = idx + 1
                     if player is None:

--- a/ui/dialog/wizard/projection_import.py
+++ b/ui/dialog/wizard/projection_import.py
@@ -244,27 +244,14 @@ class Step1(tk.Frame):
                     df_name = string_util.normalize(self.hitter_df.at[id, 'NAME'])
                     if df_name != player.search_name:
                         raise InputException(f'The input IdType {self.id_type.get()} appears wrong for this projection set.')
-        except FangraphsException as e:
+        except (FangraphsException, DavenportException, InputException) as e:
             self.parent.projection = None
             self.parent.validate_msg = e.validation_msgs
-            #mb.showerror('Error retrieving projection',  )
-            #self.parent.lift()
-            #self.parent.focus_force()
-            return False
-        except InputException as e:
-            self.parent.projection = None
-            self.parent.validate_msg = e.validation_msgs
-            #mb.showerror('Error uploading projections', f'{e.args[0]}\n{msgs}')
-            #self.parent.lift()
-            #self.parent.focus_force()
             return False
         except Exception as Argument:
             self.parent.projection = None
             logging.exception("Error retrieving projections")
             self.parent.validate_msg = 'Error retrieving projection. See log file for details.'
-            #mb.showerror('Error retrieving projection', 'See log file for details.')
-            #self.parent.lift()
-            #self.parent.focus_force()
             return False
         finally:
             pd.complete()

--- a/ui/tool/tkHyperlinkManager.py
+++ b/ui/tool/tkHyperlinkManager.py
@@ -1,0 +1,32 @@
+from tkinter import *
+
+class HyperlinkManager:
+    def __init__(self, text):
+        self.text = text
+        self.text.tag_config("hyper", foreground="blue", underline=1)
+        self.text.tag_bind("hyper", "<Enter>", self._enter)
+        self.text.tag_bind("hyper", "<Leave>", self._leave)
+        self.text.tag_bind("hyper", "<Button-1>", self._click)
+        self.reset()
+
+    def reset(self):
+        self.links = {}
+
+    def add(self, action):
+        # add an action to the manager.  returns tags to use in
+        # associated text widget
+        tag = "hyper-%d" % len(self.links)
+        self.links[tag] = action
+        return "hyper", tag
+
+    def _enter(self, event):
+        self.text.config(cursor="hand2")
+
+    def _leave(self, event):
+        self.text.config(cursor="")
+
+    def _click(self, event):
+        for tag in self.text.tag_names(CURRENT):
+            if tag[:6] == "hyper-":
+                self.links[tag]()
+                return


### PR DESCRIPTION
Closes #47. Scraping methods for Davenport projections and linking of players via MLB Id and usage of pybaseball reverse playerid lookup to find the corresponding FG major league id. Minor league ids found via name search and team match.